### PR TITLE
plugin: implementing the example with the class exstention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ docker/sandbox/lightning_dir_one/lightningd-regtest.pid
 *.info
 
 packages/cln_plugin/cln_dart
+
+packages/cln_plugin/cln_class_dart

--- a/packages/cln_plugin/Makefile
+++ b/packages/cln_plugin/Makefile
@@ -14,6 +14,7 @@ fmt:
 
 examples:
 	$(CC) compile exe example/cln_plugin_example.dart -o cln_dart
+	$(CC) compile exe example/cln_plugin_class_example.dart -o cln_class_dart
 
 gen:
 	$(CC) run build_runner build

--- a/packages/cln_plugin/example/cln_plugin_class_example.dart
+++ b/packages/cln_plugin/example/cln_plugin_class_example.dart
@@ -1,0 +1,38 @@
+import 'package:cln_plugin/cln_plugin.dart';
+
+/// N.B. This style of developing a plugin is the suggested one
+/// for middle and big plugin.
+///
+/// This involve the possibility to develop in a more OOP style the
+/// code, but also to keep the code clean a simple to read.
+
+class MyPlugin extends Plugin {
+  Future<Map<String, Object>> firstMethod(
+      Plugin plugin, Map<String, Object> request) {
+    return Future.value({
+      "foo_opt": getOpt(key: "foo_opt"),
+    });
+  }
+
+  @override
+  void configurePlugin() {
+    // This is the standard way to register a plugin
+    registerOption(
+        name: "foo_opt",
+        type: "string",
+        def: "hello",
+        description: "This is an example of how the option looks like");
+
+    /// This is the standard way to register a custom rpc method
+    registerRPCMethod(
+        name: "first_method",
+        usage: "",
+        description: "This is an example of custom rpc method",
+        callback: (plugin, request) => firstMethod(plugin, request));
+  }
+}
+
+void main() {
+  var plugin = MyPlugin();
+  plugin.start();
+}

--- a/packages/cln_plugin/lib/src/cln_plugin_base.dart
+++ b/packages/cln_plugin/lib/src/cln_plugin_base.dart
@@ -42,7 +42,7 @@ class Plugin implements CLNPlugin {
   /// that core lightning send to us.
   Map<String, Object> configuration = {};
 
-  Plugin({this.dynamic = false});
+  Plugin({this.dynamic = true});
 
   @override
   void registerFeature({required String name, required String value}) {
@@ -55,7 +55,7 @@ class Plugin implements CLNPlugin {
       required String type,
       required String def,
       required String description,
-      required bool deprecated}) {
+      bool deprecated = false}) {
     options[name] = Option(
         name: name,
         type: type,
@@ -125,9 +125,12 @@ class Plugin implements CLNPlugin {
     return Future.value({});
   }
 
+  /// configurePlugin is used to configure the plugin that extend this class
+  void configurePlugin() {}
+
   // init plugin used to register the rpc method required by the plugin
   // life cycle
-  void configurePlugin() {
+  void _defaultPluginConfiguration() {
     rpcMethods["getmanifest"] =
         GetManifest(callback: (Plugin plugin, Map<String, Object> request) {
       return getManifest(plugin, request);
@@ -135,6 +138,7 @@ class Plugin implements CLNPlugin {
     rpcMethods["init"] = InitMethod(
         callback: (Plugin plugin, Map<String, Object> request) =>
             init(plugin, request));
+    configurePlugin();
   }
 
   Future<Map<String, Object>> _call(
@@ -160,7 +164,7 @@ class Plugin implements CLNPlugin {
 
   @override
   void start() async {
-    configurePlugin();
+    _defaultPluginConfiguration();
     try {
       String? messageSocket;
 


### PR DESCRIPTION
I found this pattern very cool to implement the RPC method and register it, and also this pattern may help with the annotations in the future

Build on top https://github.com/dart-lightning/lndart.clightning/pull/40